### PR TITLE
Show Date Food Items Were Added on Category Show Page

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -47,6 +47,7 @@
       <th>Name</th>
       <th>Units</th>
       <th>Expiration date</th>
+      <th>Date Added</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -57,6 +58,7 @@
         <td><%= food_item.name %></td>
         <td><%= food_item.units %> <%= food_item.category.unit_type %></td>
         <td><%= food_item.expiration_date %></td>
+        <td><%= food_item.created_at.to_date %></td>
         <td><%= link_to 'Show', [@storage_type, @category, food_item] %></td>
         <td><%= link_to 'Edit', edit_storage_type_category_food_item_path(@storage_type, @category, food_item) %></td>
         <td><%= link_to 'Destroy', [@storage_type, @category, food_item], method: :delete, data: { confirm: 'Are you sure?' } %></td>


### PR DESCRIPTION
## Goal
This will make it easier to tell which items were added recently. For example, Tabitha wanted to know which items we added to our food storage on the last grocery trip receipt.

## Demo
![image](https://user-images.githubusercontent.com/6520489/82706360-a47c5480-9c36-11ea-816c-908ad41bd428.png)