### PR TITLE
Improve How Weights Are Displayed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -136,3 +136,8 @@ RSpec/NotToNot:
   Description: Checks for consistent method usage for negating expectations.
   EnforcedStyle: to_not
   Enabled: true
+
+RSpec/NestedGroups:
+  Description: Checks for nested example groups.
+  Max: 5
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
   gem "web-console", ">= 3.3.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
+  gem "spring-commands-rspec"
   gem "spring-watcher-listen", "~> 2.0.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,8 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     spring (2.1.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -289,6 +291,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   selenium-webdriver
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data

--- a/app/helpers/food_items_helper.rb
+++ b/app/helpers/food_items_helper.rb
@@ -1,4 +1,26 @@
 # frozen_string_literal: true
 
 module FoodItemsHelper
+  def format_units(units, unit_type)
+    unit_type = "units" if unit_type == "quantity"
+
+    displayed_unit_type = (units == 1 ? unit_type.singularize : unit_type)
+
+    if unit_type == "pounds" && units < 4 && !whole_number?(units)
+      displayed_unit_type = "ounces"
+      units = (units * 16)
+    end
+
+    "#{round(units)} #{displayed_unit_type}"
+  end
+
+  private
+
+  def whole_number?(number)
+    (number % 1).zero?
+  end
+
+  def round(number)
+    whole_number?(number) ? number.to_i : number.round(2)
+  end
 end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -22,7 +22,7 @@
 
 <p>
   <strong>Total Units:</strong>
-  <%= "#{@category.total_units} #{@category.unit_type}" %>
+  <%= format_units(@category.total_units, @category.unit_type) %>
 </p>
 
 <p>
@@ -58,7 +58,7 @@
       <% @food_items.sort_by { |food_item| [food_item.name, food_item.expiration_date] }.each do |food_item| %>
         <tr>
           <td><%= link_to food_item.name, [@storage_type, @category, food_item] %></td>
-          <td><%= food_item.units %> <%= food_item.category.unit_type %></td>
+          <td><%= format_units(food_item.units, food_item.category.unit_type) %></td>
           <td><%= food_item.expiration_date.strftime("%m-%Y") %></td>
           <td><%= food_item.created_at.strftime("%b-%d-%Y") %></td>
           <td>

--- a/app/views/food_items/show.html.erb
+++ b/app/views/food_items/show.html.erb
@@ -17,7 +17,7 @@
 
 <p>
   <strong>Units:</strong>
-  <%= @food_item.units %> <%= @food_item.category.unit_type %>
+  <%= format_units(@food_item.units, @food_item.category.unit_type) %>
 </p>
 
 <p>

--- a/spec/helpers/food_items_helper_spec.rb
+++ b/spec/helpers/food_items_helper_spec.rb
@@ -2,16 +2,54 @@
 
 require "rails_helper"
 
-# Specs in this file have access to a helper object that includes
-# the FoodItemsHelper. For example:
-#
-# describe FoodItemsHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe FoodItemsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#format_units" do
+    context "when the unit type is pounds" do
+      context "when the weight is less than 4 pounds" do
+        it "returns the weight in ounces" do
+          expect(format_units(0.5, "pounds")).to eq("8 ounces")
+          expect(format_units(2.5, "pounds")).to eq("40 ounces")
+          expect(format_units(3.75, "pounds")).to eq("60 ounces")
+          expect(format_units(3.333, "pounds")).to eq("53.33 ounces")
+        end
+
+        context "when the weight is a whole number" do
+          it "returns the weight as a whole number" do
+            expect(format_units(1, "pounds")).to eq("1 pound")
+            expect(format_units(2, "pounds")).to eq("2 pounds")
+            expect(format_units(3, "pounds")).to eq("3 pounds")
+          end
+        end
+      end
+
+      context "when the weight is greater than or equal to 4 pounds" do
+        it "returns the weight in pounds" do
+          expect(format_units(4, "pounds")).to eq("4 pounds")
+          expect(format_units(45, "pounds")).to eq("45 pounds")
+          expect(format_units(5.25, "pounds")).to eq("5.25 pounds")
+          expect(format_units(12.3921, "pounds")).to eq("12.39 pounds")
+        end
+      end
+    end
+
+    context "when the unit type is servings" do
+      it "returns servings" do
+        expect(format_units(10, "servings")).to eq("10 servings")
+      end
+
+      it "returns singular servings" do
+        expect(format_units(1, "servings")).to eq("1 serving")
+      end
+    end
+
+    context "when the unit type is quantity" do
+      it "returns units" do
+        expect(format_units(10, "quantity")).to eq("10 units")
+      end
+
+      it "returns singular units" do
+        expect(format_units(1, "quantity")).to eq("1 unit")
+      end
+    end
+  end
 end


### PR DESCRIPTION
GitKraken Story: [FSI-13](https://app.gitkraken.com/glo/view/card/cc6d07fc0a714eee892f2aadf68daeae)

This branch improves how weights are displayed to be more user-friendly. It's also intended to display weight in the same way food packaging usually does.

If the weight is less than 4 pounds, it's displayed in ounces ("20 ounces"). If it's less than 4 pounds and a whole number, it's displayed as pounds ("1 pound", "2 pounds"). If it's greater than or equal to 4 pounds, it's displayed as pounds ("20 pounds", "30.25 pounds"). Fractional pounds and ounces are rounded to 2 decimal places, and whole numbers are displayed as integers.

This branch also improves how units of type "quantity" are displayed. They're shown as "X units".

Finally, it handles pluralization correctly ("1 unit", "2 units", "1 serving", "2 servings", etc.).