### PR TITLE
Redirect from the Homepage to the Dashboard when Signed In

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  def home; end
+  def home
+    redirect_to dashboard_path if signed_in?
+  end
 end


### PR DESCRIPTION
If a user is signed in, there's not much value in them viewing the homepage. I think it will be more helpful if we redirect them to their dashboard.