### PR TITLE
Remove the Date Added Column from Food Item Tables

### DIFF
--- a/app/views/food_items/_table.html.erb
+++ b/app/views/food_items/_table.html.erb
@@ -5,7 +5,6 @@
         <th>Name</th>
         <th>Units</th>
         <th>Exp. Date</th>
-        <th>Date Added</th>
         <th>Edit</th>
         <th>Delete</th>
       </tr>
@@ -17,7 +16,6 @@
           <td><%= link_to food_item.name, [food_item.storage_type, food_item.category, food_item] %></td>
           <td><%= format_units(food_item.units, food_item.category.unit_type) %></td>
           <td><%= food_item.expiration_date.strftime("%m-%Y") %></td>
-          <td><%= food_item.created_at.strftime("%b-%d-%Y") %></td>
           <td>
             <%= render "edit_button", path: edit_storage_type_category_food_item_path(food_item.storage_type, food_item.category, food_item) %>
           </td>


### PR DESCRIPTION
I originally added the date added column because I thought it'd be helpful to see when you added a particular item, but it takes up too much space on mobile devices and it creates potential confusion with the expiration date.

---------------------------------

## After Creating the Pull Request

* [ ] Ensure CI passes.
* [ ] Test changes in review app.
* [ ] Add comment stating the review app is working correctly.
* [ ] Mark pull request as ready to review.
* [ ] Remember to include PR description in merge commit body.
* [ ] Note how many hours the task took compared to my forecast.
* [ ] Remember to update project management ticket once merged.